### PR TITLE
dicom tagg jämförelse

### DIFF
--- a/utils/Script/compare_dicom_files.ipynb
+++ b/utils/Script/compare_dicom_files.ipynb
@@ -1,0 +1,92 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "83ecf7de",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pydicom\n",
+    "from pathlib import Path\n",
+    "from typing import Dict\n",
+    "\n",
+    "def compare_dicom_fields(path_file1: Path, path_file2: Path)-> Dict:\n",
+    "    \"\"\n",
+    "    d1 = pydicom.dcmread(path_file1)\n",
+    "    d2 = pydicom.dcmread(path_file2)\n",
+    "\n",
+    "    # Alla taggar i respektive fil\n",
+    "    tags1 = {elem.tag for elem in d1}\n",
+    "    tags2 = {elem.tag for elem in d2}\n",
+    "\n",
+    "    # Taggar som finns i båda\n",
+    "    common_tags = tags1 & tags2\n",
+    "\n",
+    "    same_fields = []\n",
+    "    different_fields = []\n",
+    "\n",
+    "    for tag in common_tags:\n",
+    "        if d1[tag].value == d2[tag].value:\n",
+    "            same_fields.append((tag, d1[tag].name))\n",
+    "        else:\n",
+    "            different_fields.append((tag, d1[tag].name))\n",
+    "\n",
+    "    # Taggar som finns i endast ena filen\n",
+    "    unique_tags = tags1 ^ tags2\n",
+    "    unique_fields = []\n",
+    "\n",
+    "    for tag in unique_tags:\n",
+    "        if tag in d1:\n",
+    "            unique_fields.append((tag, d1[tag].name))\n",
+    "        else:\n",
+    "            unique_fields.append((tag, d2[tag].name))\n",
+    "\n",
+    "    return {\n",
+    "        \"same\": same_fields,\n",
+    "        \"different\": different_fields,\n",
+    "        \"unique\": unique_fields\n",
+    "    }\n",
+    "\n",
+    "# användning:\n",
+    "\n",
+    "# paths till dom två dicom filerna som ska jämforas\n",
+    "# file_1 = Path(r\"\")\n",
+    "# file_2 = Path(r\"\")\n",
+    "\n",
+    "# fields = compare_dicom_fields(file_1, file_2)\n",
+    "\n",
+    "# printa ut fields[\"same\"], fields[\"different\"] och fields[\"unique\"] for att se var DICOM filerna skiljer sig.\n",
+    "# Funktion framtagen i samband med felsokning av skick mellan capture dator och PACS.\n",
+    "\n",
+    "# print(f'\\nfält som är samma i båda dcm filerna:\\n')\n",
+    "# [print(item) for item in fields[\"same\"]]\n",
+    "# print(f'\\nfält som är olika i båda dcm filerna:\\n')\n",
+    "# [print(item) for item in fields[\"different\"]]\n",
+    "# print(f'\\nfält som är unika for någon av dcm filerna:\\n')\n",
+    "# [print(item) for item in fields[\"unique\"]]"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.14.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Enkel funktion som printar ut vilka taggar som skiljer sig, är lika, och unika mellan två olika dicom-filer. 

Kod framtagen i en felsökning där skick från capturedator till PACS strulat.

För review: Testa använd funktionen på två dcm filer som inte är identiska.